### PR TITLE
Fix android12/13 crash

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
     buildToolsVersion "29.0.3"
     ndkVersion "22.1.7171670"
     defaultConfig {
         applicationId "org.cimbar.camerafilecopy"
         minSdkVersion 21
-        targetSdkVersion 32
+        targetSdkVersion 30
         versionCode 7
         versionName "0.5.11"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -29,7 +29,7 @@ android {
     externalNativeBuild {
         cmake {
             path "src/cpp/CMakeLists.txt"
-            version "3.10.2"
+            version "3.16.3"
         }
     }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "org.cimbar.camerafilecopy"
         minSdkVersion 21
         targetSdkVersion 30
-        versionCode 7
-        versionName "0.5.11"
+        versionCode 8
+        versionName "0.5.12"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {

--- a/app/src/cpp/cfc-cpp/jni.cpp
+++ b/app/src/cpp/cfc-cpp/jni.cpp
@@ -119,7 +119,7 @@ namespace {
 	{
 		std::stringstream sstop;
 		sstop << "cfc using " << proc.num_threads() << " thread(s). " << proc.color_bits() << "..." << proc.backlog() << "? ";
-		sstop << (MultiThreadedDecoder::bytes / std::max<double>(1, MultiThreadedDecoder::decoded)) << "b v0.5.11a";
+		sstop << (MultiThreadedDecoder::bytes / std::max<double>(1, MultiThreadedDecoder::decoded)) << "b v0.5.12";
 		std::stringstream ssmid;
 		ssmid << "#: " << MultiThreadedDecoder::perfect << " / " << MultiThreadedDecoder::decoded << " / " << MultiThreadedDecoder::scanned << " / " << _calls;
 		std::stringstream ssperf;

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,6 @@
           package="org.cimbar.camerafilecopy">
 
     <uses-permission android:name="android.permission.CAMERA"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-feature android:name="android.hardware.camera" android:required="true"/>
     <uses-feature android:name="android.hardware.camera.autofocus" android:required="true"/>
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ subprojects {
     afterEvaluate {
             configure(android.lintOptions) {
                 abortOnError false
+                checkReleaseBuilds false
             }
     }
 }


### PR DESCRIPTION
This should address #14.

There's a mysterious interaction between setting `targetSdkVersion` >= 32 and either the old NDK version *or* the old opencv version that results in a consistent crash. My wild guess is it's the NDK, but the upshot should be:

1. this PR should fix the issue
2. the version in the android play store will continue to be broken, because Google won't let me update the apk without setting the `targetSdkVersion` to >= 32. :upside_down_face: 

Misc notes, NDK upgrade edition:
*  (currently `22.1.7171670` -- I ran into issues with 23.x, and pretty noticeable bad performance with 24.x)

Misc notes, opencv upgrade edition:
*  (currently 4.4 -- I've run into issues with both 4.6 and 4.7 🫠 )