### PR TITLE
Downgrade sdk/ndk versions to fix fdroid build.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,11 +3,11 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion 33
     buildToolsVersion "29.0.3"
-    ndkVersion "25.2.9519653"
+    ndkVersion "22.1.7171670"
     defaultConfig {
         applicationId "org.cimbar.camerafilecopy"
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 30
         versionCode 9
         versionName "0.5.13"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
This is not a case of "fdroid doesn't work" -- it's a build system problem, and the fdroid builds are catching it. A gradle upgrade might resolve it. For now, I'll go the somewhat tortured route of building against 33+25.2 when we need new builds in the play store, and leaving the checked in build.gradle like this.

:grimacing:

#20 