### PR TITLE
Require cimbar-js-bits submodule for gradle build/package

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "org.cimbar.camerafilecopy"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 22
-        versionName "0.6.4"
+        versionCode 23
+        versionName "0.6.4f"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         ndk {
             abiFilters "arm64-v8a"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,3 +44,10 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation project(path: ':opencv')
 }
+
+preBuild.doFirst {
+    if (!file("src/main/assets/cimbar_js.html").exists()) {
+        throw new GradleException("Missing cimbar-js-bits submodule?")
+    }
+}
+


### PR DESCRIPTION
Follow up to #57 / #60. "resolves" #63 (not really, but it'll prevent the next build from being in a sneaky-broken state)

Basically, we shouldn't be calling it a successful build if the encoder submodule is missing.