### PR TITLE
Switch webview to use wasm + use cimbar.js's new webworker impl + ... mime types?

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,19 +44,14 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.webkit:webkit:1.8.0'
     implementation project(path: ':opencv')
 }
 
 preBuild.doFirst {
-    def cimbarJs = file("src/main/assets/cimbar_js.html")
+    def cimbarJs = file("src/main/assets/index.html")
     if (!cimbarJs.exists()) {
         throw new GradleException("Missing cimbar-js-bits submodule?")
-    }
-    def digest = java.security.MessageDigest.getInstance("SHA-256")
-    def actual = digest.digest(cimbarJs.bytes).collect { String.format("%02x", it) }.join("")
-	def expected = "3c3163323c2471f3f4b795f244145cda76f1ab23dc66f6ac09fb288ae9d26db6" // v0.6.5
-    if (actual != expected) {
-        throw new GradleException("cimbar-js-bits SHA-256 mismatch :(\n  expected: ${expected}\n  actual:   ${actual}")
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.cimbar.camerafilecopy"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 24
-        versionName "0.6.6"
+        versionCode 25
+        versionName "0.6.6g"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         ndk {
             abiFilters "arm64-v8a"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,9 +49,16 @@ dependencies {
 }
 
 preBuild.doFirst {
-    def cimbarJs = file("src/main/assets/index.html")
-    if (!cimbarJs.exists()) {
-        throw new GradleException("Missing cimbar-js-bits submodule?")
+    def indexHtml = file("src/main/assets/index.html")
+    if (!indexHtml.exists()) {
+        throw new GradleException("Missing cimbar-js-bits submodule? (index.html)")
+    }
+    def cimbarJs = fileTree("src/main/assets").include("cimbar_js.*.wasm").singleFile
+    def digest = java.security.MessageDigest.getInstance("SHA-256")
+    def actual = digest.digest(cimbarJs.bytes).collect { String.format("%02x", it) }.join("")
+	def expected = "4b10483127d403ea3873ee751454afdc5d42eb5818f8b02e4c2ed0d49e2072ec" // v0.6.7
+    if (actual != expected) {
+        throw new GradleException("cimbar-js-bits SHA-256 mismatch :(\n  expected: ${expected}\n  actual:   ${actual}")
     }
 }
 

--- a/app/src/cpp/cfc-cpp/jni.cpp
+++ b/app/src/cpp/cfc-cpp/jni.cpp
@@ -71,17 +71,17 @@ namespace {
 		int outlinex = lx - outlineOffset;
 		int outliney = ty - outlineOffset;
 		cv::line(mat, cv::Point(lx, outliney), cv::Point(lx + guideLength, outliney), outline, outlineWidth);
-		cv::line(mat, cv::Point(outlinex, guideOffset), cv::Point(outlinex, ty + guideLength), outline, outlineWidth);
-		cv::line(mat, cv::Point(lx, guideOffset), cv::Point(lx + guideLength, ty), color, guideWidth);
-		cv::line(mat, cv::Point(lx, guideOffset), cv::Point(lx, ty + guideLength), color, guideWidth);
+		cv::line(mat, cv::Point(outlinex, ty), cv::Point(outlinex, ty + guideLength), outline, outlineWidth);
+		cv::line(mat, cv::Point(lx, ty), cv::Point(lx + guideLength, ty), color, guideWidth);
+		cv::line(mat, cv::Point(lx, ty), cv::Point(lx, ty + guideLength), color, guideWidth);
 
 		int rx = mat.cols - guideOffset - guideWidth - xextra;
 		outlinex = rx + outlineOffset;
 		outliney = ty - outlineOffset;
 		cv::line(mat, cv::Point(rx, outliney), cv::Point(rx - guideLength, outliney), outline, outlineWidth);
-		cv::line(mat, cv::Point(outlinex, guideOffset), cv::Point(outlinex, ty + guideLength), outline, outlineWidth);
-		cv::line(mat, cv::Point(rx, guideOffset), cv::Point(rx - guideLength, ty), color, guideWidth);
-		cv::line(mat, cv::Point(rx, guideOffset), cv::Point(rx, ty + guideLength), color, guideWidth);
+		cv::line(mat, cv::Point(outlinex, ty), cv::Point(outlinex, ty + guideLength), outline, outlineWidth);
+		cv::line(mat, cv::Point(rx, ty), cv::Point(rx - guideLength, ty), color, guideWidth);
+		cv::line(mat, cv::Point(rx, ty), cv::Point(rx, ty + guideLength), color, guideWidth);
 
 		int by = mat.rows - guideOffset - guideWidth - yextra;
 		outlinex = lx - outlineOffset;
@@ -125,7 +125,7 @@ namespace {
 	{
 		std::stringstream sstop;
 		sstop << "cfc using " << proc.num_threads() << " thread(s). " << proc.mode() << ":" << proc.detected_mode() << "..." << proc.backlog() << "? ";
-		sstop << (MultiThreadedDecoder::bytes / std::max<double>(1, MultiThreadedDecoder::decoded)) << "b v0.6.6";
+		sstop << (MultiThreadedDecoder::bytes / std::max<double>(1, MultiThreadedDecoder::decoded)) << "b v0.6.7";
 		std::stringstream ssmid;
 		ssmid << "#: " << MultiThreadedDecoder::perfect << " / " << MultiThreadedDecoder::decoded << " / " << MultiThreadedDecoder::scanned << " / " << _calls;
 		std::stringstream ssperf;
@@ -144,11 +144,11 @@ namespace {
 
 		/*std::stringstream ssperf2;
 		ssperf2 << "reader ctor: " << millis(Decoder::readerInitTicks, MultiThreadedDecoder::decoded);
-		ssperf2 << ", fount: " << millis(Decoder::fountTicks, MultiThreadedDecoder::decoded);
-		ssperf2 << ", dodecode: " << millis(Decoder::decodeTicks, MultiThreadedDecoder::decoded);
-		ssperf2 << ", readloop: " << millis(Decoder::bbTicks, MultiThreadedDecoder::decoded);
 		ssperf2 << ", rss: " << millis(Decoder::rssTicks, MultiThreadedDecoder::decoded);
-		cv::putText(mat, ssperf2.str(), cv::Point(5,300), cv::FONT_HERSHEY_DUPLEX, 1, cv::Scalar(255,255,80), 2);
+		ssperf2 << ", symbol: " << millis(Decoder::symbolTicks, MultiThreadedDecoder::decoded);
+		ssperf2 << ", color: " << millis(Decoder::colorTicks, MultiThreadedDecoder::decoded);
+		ssperf2 << ", ccm: " << millis(Decoder::ccmTicks, MultiThreadedDecoder::decoded);
+		cv::putText(mat, ssperf2.str(), cv::Point(5,250), cv::FONT_HERSHEY_DUPLEX, 1, cv::Scalar(255,255,80), 2);
 		//*/
 	}
 

--- a/app/src/main/java/org/cimbar/camerafilecopy/MainActivity.java
+++ b/app/src/main/java/org/cimbar/camerafilecopy/MainActivity.java
@@ -15,6 +15,7 @@ import android.view.GestureDetector;
 import android.view.MotionEvent;
 import android.view.SurfaceView;
 import android.view.WindowManager;
+import android.webkit.MimeTypeMap;
 import android.widget.CompoundButton;
 import android.widget.Toast;
 import androidx.annotation.Nullable;
@@ -176,7 +177,7 @@ public class MainActivity extends CameraActivity implements CvCameraViewListener
         else if (!res.isEmpty()) {
             Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
             intent.addCategory(Intent.CATEGORY_OPENABLE);
-            intent.setType("application/octet-stream");
+            intent.setType(getMimeType(res));
             intent.putExtra(Intent.EXTRA_TITLE, res);
             // can't get putExtra to work for extra values, so we'll save it in the class
             this.activePath = this.dataPath + "/" + res;
@@ -185,6 +186,22 @@ public class MainActivity extends CameraActivity implements CvCameraViewListener
 
         // return processed frame for live preview
         return mat;
+    }
+
+    // mimetype helper
+    protected static String getMimeType(String filename) {
+        String mt = null;
+        int extIdx = filename.lastIndexOf('.');
+        if (extIdx >= 0) {
+            String ext = filename.substring(extIdx + 1).toLowerCase();
+            if (!ext.isEmpty()) {
+                mt = MimeTypeMap.getSingleton().getMimeTypeFromExtension(ext);
+            }
+        }
+        if (mt == null) {
+            mt = "*/*";
+        }
+        return mt;
     }
 
     @Override

--- a/app/src/main/java/org/cimbar/camerafilecopy/WebViewActivity.java
+++ b/app/src/main/java/org/cimbar/camerafilecopy/WebViewActivity.java
@@ -75,7 +75,7 @@ public class WebViewActivity extends Activity {
             }
         });
 
-        webView.loadUrl("https://appassets.androidplatform.net/assets/index.html");
+        webView.loadUrl("https://appassets.androidplatform.net/assets/index.html#ww=1");
 
         // Set up the swipe gestures
         mDetector = new GestureDetectorCompat(this, new FlingGestureDetector());

--- a/app/src/main/java/org/cimbar/camerafilecopy/WebViewActivity.java
+++ b/app/src/main/java/org/cimbar/camerafilecopy/WebViewActivity.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
@@ -13,10 +14,14 @@ import android.view.View;
 import android.view.WindowManager;
 import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebResourceResponse;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
+import android.webkit.WebViewClient;
 
 import androidx.core.view.GestureDetectorCompat;
+import androidx.webkit.WebViewAssetLoader;
 
 
 public class WebViewActivity extends Activity {
@@ -40,8 +45,17 @@ public class WebViewActivity extends Activity {
         webView = findViewById(R.id.web_view);
         webViewSettings = webView.getSettings();
         webViewSettings.setJavaScriptEnabled(true);
-        webViewSettings.setAllowFileAccess(true);
-        webViewSettings.setAllowFileAccessFromFileURLs(true);
+
+        final WebViewAssetLoader assetLoader = new WebViewAssetLoader.Builder()
+                .addPathHandler("/assets/", new WebViewAssetLoader.AssetsPathHandler(this))
+                .build();
+
+        webView.setWebViewClient(new WebViewClient() {
+            @Override
+            public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+                return assetLoader.shouldInterceptRequest(request.getUrl());
+            }
+        });
 
         webView.setWebChromeClient(new WebChromeClient() {
             @Override
@@ -61,7 +75,7 @@ public class WebViewActivity extends Activity {
             }
         });
 
-        webView.loadUrl("file:///android_asset/cimbar_js.html");
+        webView.loadUrl("https://appassets.androidplatform.net/assets/index.html");
 
         // Set up the swipe gestures
         mDetector = new GestureDetectorCompat(this, new FlingGestureDetector());
@@ -77,6 +91,13 @@ public class WebViewActivity extends Activity {
     @Override
     public void onStart() {
         super.onStart();
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        getWindow().getDecorView().requestLayout();
+        overridePendingTransition(0, 0);
     }
 
     @Override
@@ -117,5 +138,4 @@ public class WebViewActivity extends Activity {
             return true;
         }
     }
-
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.3.2'
+        classpath 'com.android.tools.build:gradle:8.2.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.2'
+        classpath 'com.android.tools.build:gradle:8.3.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
for the encoder view:
* use WebViewAssetLoader, and lean on the wasm impl. This unfortunately very slightly *increases* file size because our wasm binary includes the decoder code (which we're not using :upside_down_face: ). Some work to be done there.
    * it is a bit faster though
* use cimbar_js's new (v0.6.7) webworker/offscreencanvas (background thread) for rendering. This helps the framerate a *lot* on older android devices.
* cimbar_js's file loading logic now uses larger buffer sizes (v0.6.7). Startup time when loading a file should be much faster (on my older phones, this makes it go from "unusable" to "usable")

for the decoder (default) view:
* try to set a proper mime type on file save. Some phones (https://github.com/sz3/libcimbar/issues/173) lock the file type when they see `application/octet-stream`, so we will do our best to avoid that.
* bugfix in visible "crosshair" calculation. This no visible difference (for now)