### PR TITLE
upgrades: minify enabled, dep bump, version bump, v0.6.8 libcimbar merge

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.h linguist-language=C++
+LICENSE text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,30 +27,56 @@ jobs:
           env: CXX="clang++" CC="clang"
           extra-packages: "clang"
 
+        - name: "windows msvc"
+          os: windows-latest
+
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
 
-    - name: Install dependencies
+    - name: Install dependencies (linux)
+      if: runner.os == 'Linux'
       run: sudo apt-get update && sudo apt-get install libopencv-dev libglfw3-dev libgles2-mesa-dev ${{ matrix.config.extra-packages }}
 
     - name: Create Build Environment
-      run: cmake -E make_directory ${{runner.workspace}}/build
+      run: |
+        cmake -E make_directory ${{runner.workspace}}/build
+        cmake -E make_directory ${{github.workspace}}/vcpkg-cache
 
-    - name: Configure CMake
+    - name: setup vcpkg cache (windows)
+      if: runner.os == 'Windows'
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/vcpkg-cache
+        key: vcpkg-cache-${{ runner.os }}-${{ hashFiles('vcpkg.json') }}
+        restore-keys: |
+          vcpkg-cache-${{ runner.os }}-
+
+    - name: Configure CMake (linux)
+      if: runner.os == 'Linux'
       working-directory: ${{runner.workspace}}/build
       run: ${{ matrix.config.env }} cmake $GITHUB_WORKSPACE
 
+    - name: Configure CMake (windows)
+      if: runner.os == 'Windows'
+      env:
+        VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg-cache,readwrite"
+      working-directory: ${{runner.workspace}}/build
+      run: cmake $env:GITHUB_WORKSPACE -A x64 "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+
     - name: Build
       working-directory: ${{runner.workspace}}/build
-      run: cmake --build . && cmake --install .
+      run: |
+        cmake --build . --config Release
+        cmake --install . --config Release
 
     - name: Test
       working-directory: ${{runner.workspace}}/build
       run: ctest --output-on-failure
 
     - name: Usage test
+      if: runner.os == 'Linux'
       working-directory: ${{runner.workspace}}/libcimbar/test/py
       run: python3 -m unittest
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required(VERSION 3.10)
 
+if(DEFINED CMAKE_TOOLCHAIN_FILE AND CMAKE_VERSION VERSION_GREATER_EQUAL "3.14")
+	set(X_VCPKG_APPLOCAL_DEPS_INSTALL ON CACHE BOOL "Install vcpkg runtime dependencies with executables")
+endif()
+
 project ( libcimbar )
 enable_testing()
-
-if (MSVC)
-    add_compile_options(/FI "iso646.h")
-endif()
 
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
 
@@ -15,6 +15,14 @@ endif()
 
 set(CMAKE_CXX_STANDARD 17)
 add_definitions("-DLIBCIMBAR_PROJECT_ROOT=\"${libcimbar_SOURCE_DIR}\"")
+
+# reproducible build, hopefully
+if(NOT MSVC)
+	add_compile_options(
+		-ffile-prefix-map=${CMAKE_SOURCE_DIR}=.
+		-ffile-prefix-map=${CMAKE_BINARY_DIR}=.
+	)
+endif()
 
 if("${CMAKE_BUILD_TYPE}" STREQUAL "")
 	set(CMAKE_BUILD_TYPE "RelWithDebInfo")
@@ -39,6 +47,16 @@ else()  # if not wasm, go find opencv. 3 or 4 should both work
 	include_directories(${OpenCV_INCLUDE_DIRS})
 endif()
 
+if(MSVC)
+	find_package(glfw3 CONFIG REQUIRED)
+	find_package(unofficial-angle CONFIG REQUIRED)
+	set(PLATFORM_GL unofficial::angle::libGLESv2 unofficial::angle::libEGL)
+	get_target_property(ANGLE_EGL_RELEASE_DLL unofficial::angle::libEGL IMPORTED_LOCATION_RELEASE)
+	get_target_property(ANGLE_EGL_DEBUG_DLL unofficial::angle::libEGL IMPORTED_LOCATION_DEBUG)
+else()
+	set(PLATFORM_GL GL)
+endif()
+
 if(DEFINED BUILD_PORTABLE_LINUX)
 	find_package(PkgConfig REQUIRED)
 	pkg_check_modules(OPENCV4 REQUIRED opencv4)
@@ -56,7 +74,10 @@ if(NOT DEFINED CPPFILESYSTEM)
 	set(CPPFILESYSTEM "stdc++fs")
 endif()
 
+# special snowflake MSVC section
 if(MSVC)
+	add_compile_options(/FI "iso646.h" /utf-8)
+
 	set(CPPFILESYSTEM "")
 endif()
 
@@ -104,5 +125,10 @@ include_directories(
 foreach(proj ${PROJECTS})
 	add_subdirectory(${proj} build/${proj})
 endforeach()
+
+if(MSVC)
+	install(FILES "${ANGLE_EGL_RELEASE_DLL}" DESTINATION bin CONFIGURATIONS Release RelWithDebInfo MinSizeRel)
+	install(FILES "${ANGLE_EGL_DEBUG_DLL}" DESTINATION bin CONFIGURATIONS Debug)
+endif()
 
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Crucially, because the encoder compiles to asmjs and wasm, it can run on anythin
 * wirehair - https://github.com/catid/wirehair
 * zstd - https://github.com/facebook/zstd
 
-## Build
+## Build (linux dev)
 
 1. install opencv and GLFW. On ubuntu/debian, this looks like:
 ```
@@ -69,7 +69,23 @@ make install
 
 By default, libcimbar will try to install build products under `./dist/bin/`.
 
-To build cimbar.js (what cimbar.org uses), see [WASM](WASM.md).
+### Build (windows MSVC + vcpkg)
+
+Install Visual Studio with the Desktop development with C++ workload, CMake 3.14 or newer, and [vcpkg](https://github.com/microsoft/vcpkg). Set `VCPKG_ROOT` to the vcpkg checkout, then configure and build from PowerShell:
+
+```
+cmake -S . -B build-windows -A x64 "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
+cmake --build build-windows --config Release --target cimbar_send cimbar_recv cimbar_recv2 --parallel
+cmake --install build-windows --config Release
+```
+
+The included `vcpkg.json` installs OpenCV, GLFW, and ANGLE during configuration. The executables and their runtime DLLs are installed under `./dist/bin/`.
+
+Note: native Windows is supported on a "best efforts" basis, so things may be a bit more buggy. (primary dev is for linux/android)
+
+### Build wasm (cimbar.js)
+
+To build cimbar.js (what cimbar.org uses), see [WASM](WASM.md). Or use the [latest release](https://github.com/sz3/libcimbar/releases/latest).
 
 ## Usage
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,8 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
+            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,9 +42,9 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'androidx.webkit:webkit:1.8.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.webkit:webkit:1.12.1'
     implementation project(path: ':opencv')
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,9 +8,9 @@ android {
     defaultConfig {
         applicationId "org.cimbar.camerafilecopy"
         minSdkVersion 21
-        targetSdkVersion 35
-        versionCode 26
-        versionName "0.6.7"
+        targetSdkVersion 36
+        versionCode 27
+        versionName "0.6.8"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         ndk {
             abiFilters "arm64-v8a"
@@ -57,7 +57,7 @@ preBuild.doFirst {
     def cimbarJs = fileTree("src/main/assets").include("cimbar_js.*.wasm").singleFile
     def digest = java.security.MessageDigest.getInstance("SHA-256")
     def actual = digest.digest(cimbarJs.bytes).collect { String.format("%02x", it) }.join("")
-	def expected = "4b10483127d403ea3873ee751454afdc5d42eb5818f8b02e4c2ed0d49e2072ec" // v0.6.7
+	def expected = "019a0d79419bdee0b918f409cdcfff919c172b75131dac5a36a44385151ca5af" // v0.6.8
     if (actual != expected) {
         throw new GradleException("cimbar-js-bits SHA-256 mismatch :(\n  expected: ${expected}\n  actual:   ${actual}")
     }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -26,6 +26,10 @@
     native <methods>;
 }
 
+# keep cfc classes
+-keep class org.cimbar.** { *; }
+-keepclassmembers class org.cimbar.** { *; }
+
 # Keep OpenCV Android SDK Java wrappers from being stripped
 -keep class org.opencv.** { *; }
 -keepclassmembers class org.opencv.** { *; }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -8,14 +8,25 @@
 # If your project uses WebView with JS, uncomment the following
 # and specify the fully qualified class name to the JavaScript interface
 # class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+   public *;
+}
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+# ----------------------------------------------------
+# 1. DISABLE OBFUSCATION (Keep original names)
+# ----------------------------------------------------
+-dontobfuscate
 
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+# ----------------------------------------------------
+# 2. STANDARD JNI & OPENCV KEEP RULES
+# ----------------------------------------------------
+
+# Keep all native methods and their declaring classes from being stripped
+-keepclasseswithmembernames class * {
+    native <methods>;
+}
+
+# Keep OpenCV Android SDK Java wrappers from being stripped
+-keep class org.opencv.** { *; }
+-keepclassmembers class org.opencv.** { *; }
+-dontwarn org.opencv.**

--- a/app/src/cpp/cfc-cpp/jni.cpp
+++ b/app/src/cpp/cfc-cpp/jni.cpp
@@ -125,7 +125,7 @@ namespace {
 	{
 		std::stringstream sstop;
 		sstop << "cfc using " << proc.num_threads() << " thread(s). " << proc.mode() << ":" << proc.detected_mode() << "..." << proc.backlog() << "? ";
-		sstop << (MultiThreadedDecoder::bytes / std::max<double>(1, MultiThreadedDecoder::decoded)) << "b v0.6.7";
+		sstop << (MultiThreadedDecoder::bytes / std::max<double>(1, MultiThreadedDecoder::decoded)) << "b v0.6.8";
 		std::stringstream ssmid;
 		ssmid << "#: " << MultiThreadedDecoder::perfect << " / " << MultiThreadedDecoder::decoded << " / " << MultiThreadedDecoder::scanned << " / " << _calls;
 		std::stringstream ssperf;

--- a/package-wasm.sh
+++ b/package-wasm.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-#docker run --mount type=bind,source="$(pwd)",target="/usr/src/app" -it emscripten/emsdk:5.0.0 bash
+#docker run -e SOURCE_DATE_EPOCH --mount type=bind,source="$(pwd)",target="/usr/src/app" -it emscripten/emsdk:5.0.0 bash
+# reproducible build, hopefully
 
+export SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-$(date +%s)}
 SKIP_JS=${SKIP_JS:-}
 CIMBAR_ROOT=${CIMBAR_ROOT:-/usr/src/app}
 cd $CIMBAR_ROOT

--- a/src/exe/cimbar/CMakeLists.txt
+++ b/src/exe/cimbar/CMakeLists.txt
@@ -23,11 +23,13 @@ target_link_libraries(cimbar
 	${CPPFILESYSTEM}
 )
 
-add_custom_command(
-	TARGET cimbar POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:cimbar> cimbar.dbg
-	COMMAND ${CMAKE_STRIP} -g $<TARGET_FILE:cimbar>
-)
+if(NOT MSVC)
+	add_custom_command(
+		TARGET cimbar POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:cimbar> cimbar.dbg
+		COMMAND ${CMAKE_STRIP} -g $<TARGET_FILE:cimbar>
+	)
+endif()
 
 install(
 	TARGETS cimbar

--- a/src/exe/cimbar_extract/CMakeLists.txt
+++ b/src/exe/cimbar_extract/CMakeLists.txt
@@ -18,11 +18,13 @@ target_link_libraries(cimbar_extract
 	${OPENCV_LIBS}
 )
 
-add_custom_command(
-	TARGET cimbar_extract POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:cimbar_extract> cimbar_extract.dbg
-	COMMAND ${CMAKE_STRIP} -g $<TARGET_FILE:cimbar_extract>
-)
+if(NOT MSVC)
+	add_custom_command(
+		TARGET cimbar_extract POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:cimbar_extract> cimbar_extract.dbg
+		COMMAND ${CMAKE_STRIP} -g $<TARGET_FILE:cimbar_extract>
+	)
+endif()
 
 install(
 	TARGETS cimbar_extract

--- a/src/exe/cimbar_recv/CMakeLists.txt
+++ b/src/exe/cimbar_recv/CMakeLists.txt
@@ -16,17 +16,26 @@ target_link_libraries(cimbar_recv
 	cimbar_js
 	extractor
 
-	GL
+	${PLATFORM_GL}
 	glfw
 	${OPENCV_LIBS}
 	opencv_videoio
 )
 
-add_custom_command(
-	TARGET cimbar_recv POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:cimbar_recv> cimbar_recv.dbg
-	COMMAND ${CMAKE_STRIP} -g $<TARGET_FILE:cimbar_recv>
-)
+if(MSVC)
+	add_custom_command(
+		TARGET cimbar_recv POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different
+			$<TARGET_FILE:unofficial::angle::libEGL>
+			$<TARGET_FILE_DIR:cimbar_recv>
+	)
+else()
+	add_custom_command(
+		TARGET cimbar_recv POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:cimbar_recv> cimbar_recv.dbg
+		COMMAND ${CMAKE_STRIP} -g $<TARGET_FILE:cimbar_recv>
+	)
+endif()
 
 install(
 	TARGETS cimbar_recv

--- a/src/exe/cimbar_recv2/CMakeLists.txt
+++ b/src/exe/cimbar_recv2/CMakeLists.txt
@@ -16,15 +16,29 @@ target_link_libraries(cimbar_recv2
 	cimbar_js
 	extractor
 
-	GL
+	${PLATFORM_GL}
 	glfw
 	${OPENCV_LIBS}
 	opencv_videoio
 )
 
-add_custom_command(
-	TARGET cimbar_recv2 POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:cimbar_recv2> cimbar_recv2.dbg
-	COMMAND ${CMAKE_STRIP} -g $<TARGET_FILE:cimbar_recv2>
+if(MSVC)
+	add_custom_command(
+		TARGET cimbar_recv2 POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different
+			$<TARGET_FILE:unofficial::angle::libEGL>
+			$<TARGET_FILE_DIR:cimbar_recv2>
+	)
+else()
+	add_custom_command(
+		TARGET cimbar_recv2 POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:cimbar_recv2> cimbar_recv2.dbg
+		COMMAND ${CMAKE_STRIP} -g $<TARGET_FILE:cimbar_recv2>
+	)
+endif()
+
+install(
+	TARGETS cimbar_recv2
+	DESTINATION bin
 )
 

--- a/src/exe/cimbar_send/CMakeLists.txt
+++ b/src/exe/cimbar_send/CMakeLists.txt
@@ -16,11 +16,20 @@ target_link_libraries(cimbar_send
 	cimbar_js
 )
 
-add_custom_command(
-	TARGET cimbar_send POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:cimbar_send> cimbar_send.dbg
-	COMMAND ${CMAKE_STRIP} -g $<TARGET_FILE:cimbar_send>
-)
+if(MSVC)
+	add_custom_command(
+		TARGET cimbar_send POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different
+			$<TARGET_FILE:unofficial::angle::libEGL>
+			$<TARGET_FILE_DIR:cimbar_send>
+	)
+else()
+	add_custom_command(
+		TARGET cimbar_send POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:cimbar_send> cimbar_send.dbg
+		COMMAND ${CMAKE_STRIP} -g $<TARGET_FILE:cimbar_send>
+	)
+endif()
 
 install(
 	TARGETS cimbar_send

--- a/src/lib/cimbar_js/CMakeLists.txt
+++ b/src/lib/cimbar_js/CMakeLists.txt
@@ -29,6 +29,10 @@ else()
 	)
 endif()
 
+if(MSVC)
+	target_compile_definitions(cimbar_js PUBLIC CIMBAR_USE_ANGLE)
+endif()
+
 target_link_libraries(cimbar_js
 
 	cimb_translator
@@ -83,8 +87,6 @@ endif()
 set (LINK_WASM_LIST
 	--bind -Os
 	${LINK_WASM_OPT}
-	-s USE_WEBGL2=1
-	-s MIN_WEBGL_VERSION=2
 	-s MAX_WEBGL_VERSION=2
 	-s USE_GLFW=3
 	-s WASM_BIGINT=1
@@ -111,7 +113,7 @@ if(DEFINED USE_WASM)
 
 else()  # if no wasm, ignore all that and add in GLFW libraries
 	target_link_libraries(cimbar_js
-		GL
+		${PLATFORM_GL}
 		glfw
 	)
 endif()

--- a/src/lib/compression/test/zstd_compressorTest.cpp
+++ b/src/lib/compression/test/zstd_compressorTest.cpp
@@ -15,7 +15,7 @@ using namespace cimbar;
 using namespace std;
 
 namespace {
-	using random_bytes_engine = std::independent_bits_engine<std::default_random_engine, CHAR_BIT, unsigned char>;
+	using random_bytes_engine = std::independent_bits_engine<std::default_random_engine, CHAR_BIT, unsigned>;
 
 	string big_random(size_t size)
 	{

--- a/src/lib/encoder/DecoderPlus.h
+++ b/src/lib/encoder/DecoderPlus.h
@@ -24,7 +24,7 @@ inline unsigned DecoderPlus::decode(std::string filename, std::string output)
 	cv::Mat img = cv::imread(filename);
 	cv::cvtColor(img, img, cv::COLOR_BGR2RGB);
 
-	std::ofstream f(output);
+	std::ofstream f(output,	std::ios::binary);
 	return Decoder::decode(img, f, false);
 }
 

--- a/src/lib/encoder/EncoderPlus.h
+++ b/src/lib/encoder/EncoderPlus.h
@@ -24,7 +24,7 @@ public:
 
 inline unsigned EncoderPlus::encode(const std::string& filename, std::string output_prefix)
 {
-	std::ifstream f(filename);
+	std::ifstream f(filename, std::ios::binary);
 
 	unsigned i = 0;
 	while (true)

--- a/src/lib/encoder/test/DecoderTest.cpp
+++ b/src/lib/encoder/test/DecoderTest.cpp
@@ -21,6 +21,17 @@ namespace {
 		picosha2::hash256(f, hash.begin(), hash.end());
 		return picosha2::bytes_to_hex_string(hash);
 	}
+
+	// evil hacks for MSVC
+	std::string operator/(const std::filesystem::path& lhs, const char* rhs)
+	{
+		return (lhs / std::filesystem::path(rhs)).string();
+	}
+
+	std::string operator/(const std::filesystem::path& lhs, const std::string& rhs)
+	{
+		return (lhs / std::filesystem::path(rhs)).string();
+	}
 }
 
 TEST_CASE( "DecoderTest/testDecode", "[unit]" )

--- a/src/lib/encoder/test/EncoderRoundTripTest.cpp
+++ b/src/lib/encoder/test/EncoderRoundTripTest.cpp
@@ -16,6 +16,19 @@
 #include <iostream>
 #include <string>
 
+namespace {
+	// evil hacks for MSVC
+	std::string operator/(const std::filesystem::path& lhs, const char* rhs)
+	{
+		return (lhs / std::filesystem::path(rhs)).string();
+	}
+
+	std::string operator/(const std::filesystem::path& lhs, const std::string& rhs)
+	{
+		return (lhs / std::filesystem::path(rhs)).string();
+	}
+}
+
 TEST_CASE( "EncoderRoundTripTest/testFountain.Pad", "[unit]" )
 {
 	MakeTempDirectory tempdir;
@@ -24,7 +37,7 @@ TEST_CASE( "EncoderRoundTripTest/testFountain.Pad", "[unit]" )
 	std::string outPrefix = tempdir.path() / "encoder.fountain";
 
 	{
-		std::ofstream f(inputFile);
+		std::ofstream f(inputFile, std::ios::binary);
 		f << "hello"; // 5 bytes!
 	}
 
@@ -41,7 +54,7 @@ TEST_CASE( "EncoderRoundTripTest/testFountain.Pad", "[unit]" )
 	SECTION ("default filename") {
 		// decoder
 		Decoder dec;
-		fountain_decoder_sink fds(cimbar::Config::fountain_chunk_size(), write_on_store<cimbar::zstd_decompressor<std::ofstream>>(tempdir.path()));
+		fountain_decoder_sink fds(cimbar::Config::fountain_chunk_size(), write_on_store<cimbar::zstd_decompressor<std::ofstream>>(tempdir.path().string()));
 
 		unsigned bytesDecoded = dec.decode_fountain(encodedImg, fds);
 		assertEquals( 7500, bytesDecoded );
@@ -54,7 +67,7 @@ TEST_CASE( "EncoderRoundTripTest/testFountain.Pad", "[unit]" )
 
 	SECTION ("parsed filename") {
 		Decoder dec;
-		fountain_decoder_sink fds(cimbar::Config::fountain_chunk_size(), decompress_on_store<std::ofstream>(tempdir.path()));
+		fountain_decoder_sink fds(cimbar::Config::fountain_chunk_size(), decompress_on_store<std::ofstream>(tempdir.path().string()));
 
 		unsigned bytesDecoded = dec.decode_fountain(encodedImg, fds);
 		assertEquals( 7500, bytesDecoded );
@@ -75,7 +88,7 @@ TEST_CASE( "EncoderRoundTripTest/testFountain.SinkMismatch", "[unit]" )
 	std::string outPrefix = tempdir.path() / "encoder.fountain";
 
 	{
-		std::ofstream f(inputFile);
+		std::ofstream f(inputFile, std::ios::binary);
 		f << "hello"; // 5 bytes!
 	}
 
@@ -94,7 +107,7 @@ TEST_CASE( "EncoderRoundTripTest/testFountain.SinkMismatch", "[unit]" )
 	// sink with a mismatched fountain_chunk_size
 	// importantly, the sink expects a *smaller* chunk than we'll give it...
 	// because that's a more interesting test...
-	fountain_decoder_sink fds(cimbar::Config::fountain_chunk_size()-125, write_on_store<cimbar::zstd_decompressor<std::ofstream>>(tempdir.path()));
+	fountain_decoder_sink fds(cimbar::Config::fountain_chunk_size()-125, write_on_store<cimbar::zstd_decompressor<std::ofstream>>(tempdir.path().string()));
 
 	unsigned bytesDecoded = dec.decode_fountain(encodedImg, fds);
 	assertEquals( 7500, bytesDecoded );
@@ -117,7 +130,7 @@ TEST_CASE( "EncoderRoundTripTest/testStreaming", "[unit]" )
 
 	// create decoder
 	Decoder dec;
-	fountain_decoder_sink fds(cimbar::Config::fountain_chunk_size(), write_on_store<cimbar::zstd_decompressor<std::ofstream>>(tempdir.path()));
+	fountain_decoder_sink fds(cimbar::Config::fountain_chunk_size(), write_on_store<cimbar::zstd_decompressor<std::ofstream>>(tempdir.path().string()));
 
 	// encode frames, then pass to decoder
 	for (int i = 0; i < 100; ++i)

--- a/src/lib/encoder/test/EncoderTest.cpp
+++ b/src/lib/encoder/test/EncoderTest.cpp
@@ -16,6 +16,18 @@
 #include <string>
 #include <vector>
 
+namespace {
+	// evil hacks for MSVC
+	std::string operator/(const std::filesystem::path& lhs, const char* rhs)
+	{
+		return (lhs / std::filesystem::path(rhs)).string();
+	}
+
+	std::string operator/(const std::filesystem::path& lhs, const std::string& rhs)
+	{
+		return (lhs / std::filesystem::path(rhs)).string();
+	}
+}
 
 TEST_CASE( "EncoderTest/testVanilla", "[unit]" )
 {

--- a/src/lib/extractor/test/ExtractorTest.cpp
+++ b/src/lib/extractor/test/ExtractorTest.cpp
@@ -9,6 +9,19 @@
 #include <string>
 #include <vector>
 
+namespace {
+	// evil hacks for MSVC
+	std::string operator/(const std::filesystem::path& lhs, const char* rhs)
+	{
+		return (lhs / std::filesystem::path(rhs)).string();
+	}
+
+	std::string operator/(const std::filesystem::path& lhs, const std::string& rhs)
+	{
+		return (lhs / std::filesystem::path(rhs)).string();
+	}
+}
+
 TEST_CASE( "ExtractorTest/testExtract", "[unit]" )
 {
 	MakeTempDirectory tempdir;

--- a/src/lib/fountain/FountainDecoder.h
+++ b/src/lib/fountain/FountainDecoder.h
@@ -14,7 +14,7 @@ class FountainDecoder
 {
 public:
 	FountainDecoder(size_t length, size_t packet_size)
-	    : _length(length)
+		: _length(length)
 	{
 		FountainInit::init();
 		_codec = wirehair_decoder_create(nullptr, length, packet_size);
@@ -22,7 +22,33 @@ public:
 
 	~FountainDecoder()
 	{
-		wirehair_free(_codec);
+		if (_codec)
+			wirehair_free(_codec);
+	}
+
+	// no copy
+	FountainDecoder(const FountainDecoder&) = delete;
+	FountainDecoder& operator=(const FountainDecoder&) = delete;
+
+	FountainDecoder(FountainDecoder&& other) noexcept
+		: _codec(std::exchange(other._codec, nullptr))
+		, _res(other._res)
+		, _length(other._length)
+		, _seenBlocks(std::move(other._seenBlocks))
+	{}
+
+	FountainDecoder& operator=(FountainDecoder&& other) noexcept
+	{
+		if (this != &other)
+		{
+			if (_codec)
+				wirehair_free(_codec);
+			_codec = std::exchange(other._codec, nullptr);
+			_res = other._res;
+			_length = other._length;
+			_seenBlocks = std::move(other._seenBlocks);
+		}
+		return *this;
 	}
 
 	unsigned progress() const
@@ -76,7 +102,7 @@ public:
 	}
 
 protected:
-	WirehairCodec _codec;
+	WirehairCodec _codec = nullptr;
 	WirehairResult _res;
 	size_t _length;
 	std::set<unsigned> _seenBlocks; // giving wirehair_decode the same block too many times can make it very, very upset

--- a/src/lib/fountain/FountainEncoder.h
+++ b/src/lib/fountain/FountainEncoder.h
@@ -7,16 +7,11 @@
 
 class FountainEncoder
 {
-protected:
-	void swap(FountainEncoder& other) throw()
-	{
-		std::swap(_codec, other._codec);
-		std::swap(_packetSize, other._packetSize);
-	}
-
 public:
+	FountainEncoder() = default;
+
 	FountainEncoder(const uint8_t* data, size_t length, size_t packet_size)
-	    : _packetSize(packet_size)
+		: _packetSize(packet_size)
 	{
 		FountainInit::init();
 		_codec = wirehair_encoder_create(nullptr, data, length, packet_size);
@@ -24,12 +19,28 @@ public:
 
 	~FountainEncoder()
 	{
-		wirehair_free(_codec);
+		if (_codec)
+			wirehair_free(_codec);
 	}
 
-	FountainEncoder& operator=(FountainEncoder temp)
+	// no copy
+	FountainEncoder(const FountainEncoder&) = delete;
+	FountainEncoder& operator=(const FountainEncoder&) = delete;
+
+	FountainEncoder(FountainEncoder&& other) noexcept
+		: _codec(std::exchange(other._codec, nullptr))
+		, _packetSize(other._packetSize)
+	{}
+
+	FountainEncoder& operator=(FountainEncoder&& other) noexcept
 	{
-		temp.swap(*this);
+		if (this != &other)
+		{
+			if (_codec)
+				wirehair_free(_codec);
+			_codec = std::exchange(other._codec, nullptr);
+			_packetSize = other._packetSize;
+		}
 		return *this;
 	}
 
@@ -54,6 +65,6 @@ public:
 	}
 
 protected:
-	WirehairCodec _codec;
+	WirehairCodec _codec = nullptr;
 	size_t _packetSize;
 };

--- a/src/lib/fountain/fountain_decoder_sink.h
+++ b/src/lib/fountain/fountain_decoder_sink.h
@@ -54,7 +54,7 @@ class fountain_decoder_sink
 {
 public:
 	fountain_decoder_sink(unsigned chunk_size, const std::function<std::string(const std::string&, const std::vector<uint8_t>&)>& on_store=nullptr)
-		: _chunkSize(chunk_size)
+		: _chunkSize(chunk_size < 50? 50 : chunk_size)
 		, _onStore(on_store)
 	{
 	}
@@ -132,7 +132,8 @@ public:
 
 	int64_t decode_frame(const char* data, unsigned size)
 	{
-		if (size < FountainMetadata::md_size)
+		// 2nd clause is implicitly true iff 1st is... but leave it for clarity
+		if ((size%_chunkSize) > 0 or size < FountainMetadata::md_size)
 			return -10;
 
 		FountainMetadata md(data, size);

--- a/src/lib/fountain/fountain_decoder_stream.h
+++ b/src/lib/fountain/fountain_decoder_stream.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "FountainDecoder.h"
+#include "FountainMetadata.h"
 #include <optional>
 #include <string>
 
@@ -46,16 +47,13 @@ public:
 	{
 		// if we're full
 		_buffIndex = 0;
-		// we ignore the first 4 bytes. It's the sink's job to make sure we're getting the right stuff.
-		// we may, at some point, sanity check if data_size == [1]+[2]+[3]
-		unsigned blockId = (unsigned)(_buffer[4]) << 8 | _buffer[5];
-		return _decoder.decode(blockId, _buffer.data() + _headerSize, block_size());
+		FountainMetadata md(reinterpret_cast<const char*>(_buffer.data()), 6);
+		if (data_size() != md.file_size())
+			return false; // sanity check
+		return _decoder.decode(md.block_id(), _buffer.data() + _headerSize, block_size());
 	}
 
-	// we need to track either:
-	// 1. all packet header locations + current location in frame buffer to correlate
-	// 2. current location in frame buffer to see if we're at a packet header location
-	// 3. special case of #2, where we just roll forward every _bufferSize bytes?
+	// roll forward every _bufferSize bytes
 	bool write(const char* data, unsigned length)
 	{
 		while (length > 0 and good())

--- a/src/lib/fountain/test/fountain_sinkSpecialTest.cpp
+++ b/src/lib/fountain/test/fountain_sinkSpecialTest.cpp
@@ -58,11 +58,11 @@ TEST_CASE( "FountainSinkSpecialTest/testMultipart", "[unit]" )
 	::srand( ::time(nullptr) );
 	MakeTempDirectory tempdir;
 
-	fountain_decoder_sink sink(750, write_on_store<std::ofstream>(tempdir.path()));
+	fountain_decoder_sink sink(750, write_on_store<std::ofstream>(tempdir.path().string()));
 
 	const int totalSize = 6000000;
 	string randostr = random_string(2500);
-	std::cout << randostr << std::endl;
+	//std::cout << randostr << std::endl;
 	stringstream input = dummyContents(totalSize, randostr);
 	fountain_encoder_stream::ptr fes = fountain_encoder_stream::create(input, 750, 108);
 

--- a/src/lib/fountain/test/fountain_sinkTest.cpp
+++ b/src/lib/fountain/test/fountain_sinkTest.cpp
@@ -54,7 +54,7 @@ TEST_CASE( "FountainSinkTest/testDefault", "[unit]" )
 {
 	MakeTempDirectory tempdir;
 
-	fountain_decoder_sink sink(690, write_on_store<std::ofstream>(tempdir.path()));
+	fountain_decoder_sink sink(690, write_on_store<std::ofstream>(tempdir.path().string()));
 	string iframe = createFrame(0, 1200);
 	assertEquals( 6900, iframe.size() );
 
@@ -74,7 +74,11 @@ TEST_CASE( "FountainSinkTest/testDefault", "[unit]" )
 	assertEquals( 2, sink.num_done() );
 
 	assertEquals( "", turbo::str::join(sink.get_progress()) );
-	assertEquals( "1.1600 0.1200", turbo::str::join(sink.get_done()) );
+	{
+		auto res = sink.get_done();
+		std::sort(res.begin(), res.end());
+		assertEquals( "0.1200 1.1600", turbo::str::join(res) );
+	}
 
 	string contents = File(tempdir.path() / "0.1200").read_all();
 	assertEquals( 1200, contents.size() );
@@ -86,7 +90,7 @@ TEST_CASE( "FountainSinkTest/testMultipart", "[unit]" )
 {
 	MakeTempDirectory tempdir;
 
-	fountain_decoder_sink sink(690, write_on_store<std::ofstream>(tempdir.path()));
+	fountain_decoder_sink sink(690, write_on_store<std::ofstream>(tempdir.path().string()));
 
 	stringstream input = dummyContents(20000);
 	fountain_encoder_stream::ptr fes = fountain_encoder_stream::create(input, 690, 2);
@@ -117,7 +121,7 @@ TEST_CASE( "FountainSinkTest/testSameFrameManyTimes", "[unit]" )
 	// sometimes it's fine. The docs say "don't do it", so FountainDecoder acts as the bouncer.
 	MakeTempDirectory tempdir;
 
-	fountain_decoder_sink sink(690, write_on_store<std::ofstream>(tempdir.path()));
+	fountain_decoder_sink sink(690, write_on_store<std::ofstream>(tempdir.path().string()));
 
 	stringstream input = dummyContents(20000);
 	fountain_encoder_stream::ptr fes = fountain_encoder_stream::create(input, 690, 3);
@@ -138,4 +142,63 @@ TEST_CASE( "FountainSinkTest/testSameFrameManyTimes", "[unit]" )
 
 	assertEquals( "0.333333", turbo::str::join(sink.get_progress()) ); // 33% done
 	assertEquals( "", turbo::str::join(sink.get_done()) );
+}
+
+TEST_CASE( "FountainSinkTest/testRejection", "[unit]" )
+{
+	MakeTempDirectory tempdir;
+	fountain_decoder_sink sink(625, write_on_store<std::ofstream>(tempdir.path().string()));
+
+	stringstream input1 = dummyContents(2000);
+	fountain_encoder_stream::ptr fes1 = fountain_encoder_stream::create(input1, 625, 1);
+
+	// a non-rejection, first
+	{
+		std::array<char, 625> buff;
+		unsigned res = fes1->readsome(buff.data(), buff.size());
+		assertEquals( res, buff.size() );
+
+		// incomplete
+		assertEquals( 0, sink.decode_frame(buff.data(), buff.size()) );
+	}
+
+	// bad buffer sizes
+	{
+		std::array<char, 625> buff;
+		unsigned res = fes1->readsome(buff.data(), buff.size());
+		assertEquals( res, buff.size() );
+
+		// smaller than fountain header
+		assertEquals( -10, sink.decode_frame(buff.data(), 5) );
+
+		// not the right chunk size
+		assertEquals( -10, sink.decode_frame(buff.data(), 620) );
+	}
+
+	// bad FountainMetadata
+	{
+		std::array<char, 625> buff;
+		unsigned res = fes1->readsome(buff.data(), buff.size());
+		assertEquals( res, buff.size() );
+
+		// extract and clobber
+		FountainMetadata md(buff.data(), FountainMetadata::md_size);
+		md = FountainMetadata(md.encode_id(), 0, md.block_id());
+		std::memcpy(buff.data(), md.data(), FountainMetadata::md_size);
+
+		assertEquals( -11, sink.decode_frame(buff.data(), buff.size()) );
+	}
+
+	// different size, same encode_id
+	{
+		stringstream input2 = dummyContents(1000);
+		fountain_encoder_stream::ptr fes2 = fountain_encoder_stream::create(input2, 625, 1);
+
+		std::array<char, 625> buff;
+		unsigned res = fes2->readsome(buff.data(), buff.size());
+		assertEquals( res, buff.size() );
+
+		// slot taken
+		assertEquals( -12, sink.decode_frame(buff.data(), buff.size()) );
+	}
 }

--- a/src/lib/fountain/test/fountain_streamTest.cpp
+++ b/src/lib/fountain/test/fountain_streamTest.cpp
@@ -268,6 +268,49 @@ TEST_CASE( "FountainStreamTest/testDecode_BigPackets", "[unit]" )
 	assertEquals( 14, fes->block_count() );
 	assertEquals( 13, fes->blocks_required() );
 	assertTrue( fes->good() );
-
 }
+
+TEST_CASE( "FountainStreamTest/testDecode_RejectSizeMismatch", "[unit]" )
+{
+	stringstream input;
+	for (int i = 0; i < 100; ++i)
+		input << "0123456789";
+
+	fountain_encoder_stream::ptr fes = fountain_encoder_stream::create(input, 625);
+
+	assertEquals( 0, fes->block_count() );
+	assertEquals( 2, fes->blocks_required() );
+	assertTrue( fes->good() );
+
+	fountain_decoder_stream fdsgood(input.str().size(), 625);
+	fountain_decoder_stream fdsbad(input.str().size() + 7, 625); // size mismatch
+
+	std::array<char, 625> buff; // one block per read/write
+	for (int i = 0; i < 100; ++i)
+	{
+		unsigned res = fes->readsome(buff.data(), buff.size());
+		assertEquals( res, buff.size() );
+
+		assertFalse( fdsbad.write(buff.data(), buff.size()) ); // always reject on decode()
+
+		if (i < 2)
+		{
+			bool isdone = fdsgood.write(buff.data(), buff.size());
+			assertEquals( (i == 1), isdone );
+		}
+	}
+
+	assertEquals( 619, fdsgood.block_size() );
+	assertEquals( 1000, fdsgood.data_size() );
+	assertTrue( fdsgood.good() );
+
+	assertEquals( 619, fdsbad.block_size() );
+	assertEquals( 1007, fdsbad.data_size() );
+	assertTrue( fdsbad.good() );
+
+	assertEquals( 101, fes->block_count() );
+	assertEquals( 2, fes->blocks_required() );
+	assertTrue( fes->good() );
+}
+
 

--- a/src/lib/gui/gl_2d_display.h
+++ b/src/lib/gui/gl_2d_display.h
@@ -15,26 +15,25 @@ namespace cimbar {
 class gl_2d_display_program
 {
 protected:
-	static constexpr const char* VERTEX_SHADER_SRC = R"(#version 300 es
+	static constexpr const char* VERTEX_SHADER_SRC = R"(
 	uniform mat2 rot;
 	uniform vec2 tform;
-	in vec4 vert;
-	out vec2 texCoord;
+	attribute vec4 vert;
+	varying vec2 texCoord;
 	void main() {
-	   gl_Position = vec4(vert.x, vert.y, 0.0f, 1.0f);
+	   gl_Position = vec4(vert.x, vert.y, 0.0, 1.0);
 	   vec2 ori = vec2(vert.x, vert.y);
 	   ori *= rot;
-	   texCoord = vec2(1.0f - ori.x, 1.0f - ori.y) / 2.0;
+	   texCoord = vec2(1.0 - ori.x, 1.0 - ori.y) / 2.0;
 	   texCoord -= tform;
 	})";
 
-	static constexpr const char* FRAGMENT_SHADER_SRC = R"(#version 300 es
+	static constexpr const char* FRAGMENT_SHADER_SRC = R"(
 	precision mediump float;
 	uniform sampler2D tex;
-	in vec2 texCoord;
-	out vec4 finalColor;
+	varying vec2 texCoord;
 	void main() {
-	   finalColor = texture(tex, texCoord);
+	   gl_FragColor = texture2D(tex, texCoord);
 	})";
 
 public:

--- a/src/lib/gui/window_glfw.h
+++ b/src/lib/gui/window_glfw.h
@@ -30,6 +30,13 @@ public:
 			return;
 		}
 
+#ifdef CIMBAR_USE_ANGLE
+		glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
+		glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
+		glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+		glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
+#endif
+
 		_w = glfwCreateWindow(width, height, title.c_str(), NULL, NULL);
 		if (!_w)
 		{

--- a/src/lib/util/File.h
+++ b/src/lib/util/File.h
@@ -16,9 +16,14 @@ public:
 	}
 
 public:
-	File(std::string filename, bool write=false)
+	File(const std::string& filename, bool write=false)
 	{
 		_fp = fopen(filename.c_str(), write? "wb" : "rb");
+	}
+
+	File(const std::filesystem::path& filename, bool write=false)
+		: File(filename.string(), write)
+	{
 	}
 
 	std::string read_all()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "libcimbar",
+  "version-string": "0.6.7c",
+  "builtin-baseline": "9e593bb18ea69cc5095e012465dcd675a822ed0d",
+  "dependencies": [
+    {
+      "name": "angle",
+      "platform": "windows & !mingw"
+    },
+    "glfw3",
+    "opencv4"
+  ]
+}

--- a/web/index.html
+++ b/web/index.html
@@ -39,19 +39,23 @@
       top: 0;
     }
 
-    #nav-container:focus-within {
+    #nav-container {
       z-index: 1;
     }
 
     #nav-content,
     #nav-container .bg,
+    #nav-container:focus-within,
     #nav-container:focus-within #nav-button {
       z-index: 1;
     }
 
+    /* canvas/dragdrop */
     #canvas {
       display: block;
       position: relative;
+      z-index: 2;
+      pointer-events: none;
     }
 
     #dragdrop {
@@ -61,35 +65,60 @@
       color: #F0F0F0;
       outline: 6px solid black;
       box-shadow: 0px 0px 12px black, 0px 0px 18px black;
+      position: relative;
+      cursor: pointer;
+      z-index: 0;
     }
 
-    .dragdrop::before {
-      content: "⌜ Tap to start! ⌟";
-      font: 1.5em serif;
-      padding-top: 2em;
+    #dragdrop.active,
+    #dragdrop.active * {
+      cursor: none !important;
+    }
+
+    .drop-message {
       position: absolute;
-      left: 0;
+      inset: 0;
+      z-index: 1;
+
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: flex-start;
+      padding-top: 3em;
+      padding-bottom: 2em;
       text-align: center;
-      width: 100%;
-    }
 
-    .dragdrop.error:before {
-      content: "⌜ Error! WebGL is not enabled :( ⌟";
-    }
-
-    #invisible_click {
-      position: fixed;
-      opacity: 0;
-      pointer-events: auto;
-    }
-
-    #invisible_click.active {
-      cursor: none;
-    }
-
-    #nav-container:focus-within+#invisible_click {
       pointer-events: none;
+    }
+
+    .drop-message p {
+      font: 1.2em serif;
+      margin: 0;
+      padding-bottom: 1em;
+    }
+
+    .drop-message p:first-of-type {
+      font: 1.5em serif;
+    }
+
+    .drop-message .msg-long {
+      font: 0.9em serif;
+    }
+
+    .drop-message .msg-bottom {
+      margin-top: auto;
+    }
+
+    .drop-message .msg-error {
       display: none;
+    }
+
+    .dragdrop.error .drop-message .msg-default {
+      display: none;
+    }
+
+    .dragdrop.error .drop-message .msg-error {
+      display: block;
     }
 
     /* options */
@@ -330,16 +359,21 @@
   </style>
 
   <div id="status"></div>
-  <div id="dragdrop" class="dragdrop" title="Drag and drop a file">
+  <div id="dragdrop" class="dragdrop" title="Drag and drop a file" onclick="Main.clickNav()">
+    <div class="drop-message">
+      <p class="msg-default">⌜ Tap to start! ⌟</p>
+      <p class="msg-error">⌜ Error! WebGL is not enabled :( ⌟</p>
+      <p class="msg-default msg-bottom">⚠️⚡ PHOTOSENSITIVITY WARNING!</p>
+      <p class="msg-default msg-long">Photosensitive epilepsy + flickering light = seizure!</p>
+      <p class="msg-default msg-long">Be safe! Have fun! ⚠️⚡</p>
+    </div>
     <canvas id="canvas" class="canvas"></canvas>
   </div>
 
   <input style="display:none;" type="file" name="file_input" id="file_input" onchange="Main.fileInput(this);" />
 
-  <a id="invisible_click" href="javascript:;" onclick="Main.clickNav()"></a>
-
   <div id="nav-container" class="mode-b">
-    <div class="bg" onclick="Main.blurNav();"></div>
+    <div class="bg" onpointerdown="Main.blurNav(); event.preventDefault();"></div>
     <button id="nav-button" tabindex="0" onclick="Main.clickNav();">
       <span class="icon-bar"></span>
       <span class="icon-bar"></span>
@@ -387,6 +421,10 @@
         Main.init(canvas);
       };
     }
+  </script>
+
+  <script type="text/javascript">
+    Main.check_GL_enabled();
   </script>
   <script src="cimbar_js.js"></script>
 

--- a/web/main.js
+++ b/web/main.js
@@ -110,7 +110,6 @@ var Main = function () {
       _ww.postMessage({ fun: 'nextFrame', args: [] });
     },
 
-
     check_GL_enabled: function () {
       var testCanvas = document.createElement('canvas');
       if (!testCanvas.getContext("webgl2") && !testCanvas.getContext("webgl")) {
@@ -125,7 +124,6 @@ var Main = function () {
       var width = window.innerWidth - 10;
       var height = window.innerHeight - 10;
       Main.scaleCanvas(canvas, width, height);
-      Main.alignInvisibleClick(canvas);
       Main.checkNavButtonOverlap();
     },
 
@@ -174,17 +172,6 @@ var Main = function () {
         canvas.style.width = xdim + "px";
         canvas.style.height = ydim + "px";
       }
-    },
-
-    alignInvisibleClick: function (canvas) {
-      canvas = canvas || document.getElementById('canvas');
-      var cpos = canvas.getBoundingClientRect();
-      var invisible_click = document.getElementById("invisible_click");
-      invisible_click.style.width = canvas.style.width;
-      invisible_click.style.height = canvas.style.height;
-      invisible_click.style.top = cpos.top + "px";
-      invisible_click.style.left = cpos.left + "px";
-      invisible_click.style.zoom = canvas.style.zoom;
     },
 
     prevent_sleep: async function () {
@@ -241,9 +228,9 @@ var Main = function () {
       if (pause === undefined) {
         pause = true;
       }
-      document.getElementById("nav-button").blur();
-      document.getElementById("nav-content").blur();
-      document.getElementById("nav-find-file-link").blur();
+      if (document.activeElement && document.activeElement instanceof HTMLElement) {
+        document.activeElement.blur();
+      }
       Main.togglePause(pause);
     },
 
@@ -267,9 +254,8 @@ var Main = function () {
 
     setActive: function (active) {
       // hide cursor when there's a barcode active
-      var invisi = document.getElementById("invisible_click");
-      invisi.classList.remove("active");
-      invisi.classList.add("active");
+      var invisi = document.getElementById("dragdrop");
+      dragdrop.classList.add("active");
     },
 
     setMode: function (mode_str) {

--- a/web/pwa-recv.json
+++ b/web/pwa-recv.json
@@ -4,8 +4,8 @@
 	"name": "cimbar.org Receiver",
 	"short_name": "cimbar recv",
 	"icons": [{"src":"icon-192x192.png","sizes":"192x192","type":"image/png"},{"src":"icon-512x512.png","sizes":"512x512","type":"image/png","purpose": "any"},{"src":"icon-512x512-maskable.png","sizes":"512x512","type":"image/png","purpose": "maskable"}],
-	"scope": "/",
-	"start_url": "recv.html",
+	"scope": "/recv.html",
+	"start_url": "/recv.html",
 	"display": "fullscreen",
 	"theme_color": "aliceblue",
 	"background_color": "black"

--- a/web/recv.html
+++ b/web/recv.html
@@ -426,7 +426,7 @@
   <script type="text/javascript">
     Recv.init_ww(4);
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('./recv-sw.js');
+      navigator.serviceWorker.register('./recv-sw.js', { scope: '/recv.html' });
     }
     var video = document.querySelector('#video');
 

--- a/web/sw.js
+++ b/web/sw.js
@@ -3,6 +3,7 @@ var _cacheName = 'cimbar-js-v%VERSION%';
 var _cacheFiles = [
   '/',
   '/index.html',
+  '/index.html?ww=1',
   '/cimbar_js.js',
   '/cimbar_js.wasm',
   '/favicon.ico',

--- a/web/wasmgz.sh
+++ b/web/wasmgz.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 # run from within web dir
 # does various renames for cache busting
+# reproducible build, hopefully
 
 RENAME_FILES=$(ls cimbar_js.js cimbar_js.wasm main.js send.js send-worker.js recv.js recv-worker.js zstd.js pwa*.json)
 GSUB_FILES="index.html recv.html sw.js recv-sw.js $(echo $RENAME_FILES | sed 's/cimbar_js\.wasm//g')"
 
-VERSION=${VERSION:-$(date --utc '+%Y-%m-%dT%H%M')}
+SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-$(date +%s)}
+VERSION=${VERSION:-$(date --utc -d "@$SOURCE_DATE_EPOCH" '+%Y-%m-%dT%H%M')}
 echo $VERSION
 
 mkdir $VERSION
@@ -32,4 +34,5 @@ for f in $(echo $RENAME_FILES | xargs -n 1 | sort -u); do
 	mv $f $newname
 done
 
-tar -czvf ../cimbar.wasm.tar.gz *
+# reproducible (hopefully) tar.gz
+find . -mindepth 1 | env LC_ALL=C sort | tar --transform='s|^\./||' --mtime="@${SOURCE_DATE_EPOCH:-0}" --owner=0 --group=0 --numeric-owner  --pax-option=exthdr.name=%d/PaxHeaders/%f,atime:=0,ctime:=0 -c -T - | gzip -n > ../cimbar.wasm.tar.gz


### PR DESCRIPTION
From libcimbar v0.6.8: https://github.com/sz3/libcimbar/releases/tag/v0.6.8

* GLSL shader version downgrade!
   * turns out our rendering (encode view webview) shader can run on gles 100, which *may* be useful for some older devices. I'm not 100% sure if this will matter for the android case (might be other legacy requirements that are in the way), but it's there.
 * wasm now uses a reproducible build, which may be useful for fdroid purposes. The timestamp for v0.6.8 is `2026-08-21T2336`, with emsdk docker image=`67df07bc59f86685818fa801d340b54e576fe4276cfd3bcfc4da61d564217737` (I think? https://github.com/sz3/libcimbar/actions/runs/32537428655/job/96940847902) https://github.com/sz3/libcimbar/pull/184
* misc security/defense in depth/hardening type fixes for the decoder (see https://github.com/sz3/libcimbar/pull/185)
* the encoder view now includes an epileptic seizure warning on load. It's hopefully both unobtrusive to the user flow, and also informative that our 15fps "random static" image might be a concern for some people. https://github.com/sz3/libcimbar/pull/186

Also:
* the play store recommends (and android ecosystem increasingly requires) minification to trim down apk size after pulling in various bloated libraries. So: we have a bare bones one now (mostly targeted at... the libraries we depend on)
   * the apk *is* about 500kb smaller as a result (8.4 MB vs 8.9 for v0.6.7) 